### PR TITLE
Add support for UTF-16BE strings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,7 @@ AutoPrereqs.skip[0] = ^DateTime$
 Test::PodSpelling.stopwords[ 0] = PDF
 Test::PodSpelling.stopwords[ 1] = PNG
 Test::PodSpelling.stopwords[ 2] = initialises
+Test::PodSpelling.stopwords[ 3] = ASCIIHexDecode
 
 [Prereqs / Recommends]
 DateTime = 0

--- a/t/Renard/Incunabula/MuPDF/mutool/ObjectParser.t
+++ b/t/Renard/Incunabula/MuPDF/mutool/ObjectParser.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
-use Test::Most tests => 2;
+use utf8;
+use Test::Most tests => 3;
 
 use Renard::Incunabula::Common::Setup;
 use Renard::Incunabula::MuPDF::mutool::ObjectParser;
@@ -16,7 +17,7 @@ subtest "Unsecape" => sub {
 
 	for my $test (@tests) {
 		is(
-			Renard::Incunabula::MuPDF::mutool::ObjectParser->unescape( $test->{input} ),
+			Renard::Incunabula::MuPDF::mutool::ObjectParser->unescape_ascii_string( $test->{input} ),
 			$test->{output},
 			"unescape @{[ $test->{input} ]}"
 		);
@@ -40,6 +41,30 @@ subtest "Boolean" => sub {
 			ok( $test->{output} ? $parse->data : ! $parse->data, "Correct parsing of boolean" );
 			is( $parse->type, Renard::Incunabula::MuPDF::mutool::ObjectParser->TypeBoolean, 'Is tagged as Boolean type' );
 		}
+	}
+};
+
+subtest "Decode hex UTF-16BE" => sub {
+	my @tests = (
+		{
+			input => 'FEFF004D006900630072006F0073006F0066007400AE00200050006F0077006500720050006F0069006E007400AE00200032003000310030',
+			output => 'Microsoft® PowerPoint® 2010',
+		},
+		{
+			# with spaces
+			input => 'FE FF 00 4D 006900630072006F0073006F0066007400AE00200050006F0077006500720050006F0069006E007400AE00200032003000310030',
+			output => 'Microsoft® PowerPoint® 2010',
+		},
+	);
+
+	for my $test (@tests) {
+		binmode STDOUT, ':encoding(UTF-8)';
+		binmode STDERR, ':encoding(UTF-8)';
+		is(
+			Renard::Incunabula::MuPDF::mutool::ObjectParser->decode_hex_utf16be( $test->{input} ),
+			$test->{output},
+			"UTF-16BE decode @{[ $test->{input} ]}"
+		);
 	}
 };
 


### PR DESCRIPTION
Also renames `unescape` to `unescape_ascii_string` in order to make a
distinction between working with ASCII text strings and the Unicode
UTF-16BE hex strings.

Fixes <https://github.com/project-renard/p5-Renard-Incunabula-MuPDF-mutool/issues/7>.
